### PR TITLE
Beautiful Soup module name is 'bs4'

### DIFF
--- a/iocp/Parser.py
+++ b/iocp/Parser.py
@@ -149,7 +149,7 @@ class Parser(object):
             print(('PDF parser library not found: {}'.format(library)))
             sys.exit(-1)
 
-        if input_format in ('html', ) and 'beautifulsoup' not in sys.modules:
+        if input_format in ('html', ) and 'bs4' not in sys.modules:
             print('HTML parser library not found: BeautifulSoup')
             sys.exit(-1)
 


### PR DESCRIPTION
Hi,

I got the following error using your tool:

    $ python bin/iocp -i html index.html 
    HTML parser library not found: BeautifulSoup

I think the problem is checking for presence of module 'beautifulsoup', when the module name is actually 'bs4'.

Rauli